### PR TITLE
Added support for nested object handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ config.error = function *(error, data, app) {
 
 ### config.sockets
 
-an array of socket configurations. Each socket requires a `channel`, and a `controller`. strings can be passed in to the `controller`, but a `controllers` directory must be passed in to the config. if strings are used, they must be `.` delimited where the first work is the file, and the remaining string denotes the controller property/handler. ([see complex example for more detail](https://github.com/johnhof/rabbit-service/tree/master/examples/complex)).
+an array of socket configurations. Each socket requires a `channel`, and a `controller`. strings can be passed in to the `controller`, but a `controllers` directory must be passed in to the config. if strings are used, they must be `.` delimited where the first work is the file, and the remaining string denotes the controller property/handler chain (accepts nested objects). ([see complex example for more detail](https://github.com/johnhof/rabbit-service/tree/master/examples/complex)).
 
 
 ```javasscript

--- a/lib/service.js
+++ b/lib/service.js
@@ -58,18 +58,20 @@ module.exports = function (config) {
         }
 
         config.controllers = /\/$/.test(config.controllers) ? config.controllers : config.controllers + '/'
-        var ctrlSplit   = (socket.controller || '').split('.');
-        var ctrlPath    = config.controllers + ctrlSplit[0];
-        var ctrlHandler = ctrlSplit[1];
+        var ctrlSplit        = (socket.controller || '').split('.');
+        var ctrlPath         = config.controllers + ctrlSplit.shift();
+        var ctrlHandlerChain = ctrlSplit;
 
         try {
-          controller = require(ctrlPath);
+          controller = require(ctrlPath); // get the controller file
+          _.each(ctrlHandlerChain, function (propName) { controller = controller[propName]; }); // dig down thte property chain
 
-          if (ctrlHandler) {
-            controller = controller[ctrlHandler];
-          }
         } catch (e) {
-          return console.log('! Contoller ' + socket.controller + ' not found verify path and handler: ' + ctrlPath + ' [' +  ctrlHandler+ ']')
+          if (!~e.message.indexOf('Cannot find module \'' + ctrlPath + '\'')) {
+            console.log(e.stack)
+          }
+          console.log('! Controller ' + socket.controller + ' not found verify path and handler: ' + ctrlPath + ' [' +  ctrlHandler+ ']')
+          return;
         }
       } else if (_.isFunction(socket.controller)) {
         controller = socket.controller;
@@ -89,36 +91,38 @@ module.exports = function (config) {
       // bind the socket to the event
       //
       sockInstance.on(socket.listen, function(data){
-        var app = {
+        var socketReq = {
           context    : context,
           channel    : socket.channel,
-          controller : config.controllers ? socket.controller : 'anonymous_controller'
+          controller : config.controllers ? socket.controller : 'anonymous_controller',
+          message    : data,
         };
 
         var coreFunction = co(function *(){
           if (config.json) {
             try {
-              data = JSON.parse(data);
+              socketReq.json = JSON.parse(data);
             } catch (e) {
+              console.log(e.stack)
               throw new Error('Failed to parse message:\n' + data);
             }
           }
+
           if (config.middleware) {
-            yield config.middleware(data, app, function *(_data, _app) {
-              yield controller(_data || data, _app || app);
+            yield config.middleware.call(socketReq, function *() {
+              yield controller.call(socketReq);
             });
           } else {
-            yield controller(data, app);
+            yield controller.call(socketReq);
           }
-
         });
 
-        var genericError = function (err) { console.log(err.stack); }
+        var genericError = function *(err) { console.log(err.stack); }
 
         if (config.error) {
           coreFunction.catch(function (err) {
             co(function *() {
-              yield config.error(err, data, app);
+              yield config.error.call(socketReq, err);
             }).catch(genericError);
           });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rabbit-service",
-  "version": "3.0.0",
+  "version": "5.0.0",
   "description": "A generator based service to simplify messaging with RabbitMQ",
   "main": "lib/service.js",
   "repository" : "https://github.com/johnhof/rabbit-service",


### PR DESCRIPTION
No longer requires controllers/ handlers be included with the following constructor

``` javascript
// old fooCtrl.js 
module.exports = {
  'bar.handler' :  function *(){}
}
```

instead splits the handler by `.` and traverse's down the property chain of the controller returned

``` javascript
// new fooCtrl.js
module.exports = {
  bar : { 
    handler : function *(){}
  }
}
```
